### PR TITLE
Fix missing vitest/globals type definition error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["vite/client"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
The tsconfig.json referenced vitest/globals in the types array, but the vitest package is not installed. Since there are no test files using Vitest in the codebase, this reference was removed to fix the build.

Fixes: error TS2688: Cannot find type definition file for 'vitest/globals'